### PR TITLE
Improve student activity registration system

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/app.py
+++ b/src/app.py
@@ -105,3 +105,18 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/signup")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activity = activities[activity_name]
+
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=404, detail="Student is not signed up for this activity")
+
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Basketball Team": {
+        "description": "Competitive basketball team for intramural and regional competitions",
+        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 15,
+        "participants": ["alex@mergington.edu"]
+    },
+    "Tennis Club": {
+        "description": "Learn tennis skills and play recreational matches",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:00 PM",
+        "max_participants": 16,
+        "participants": ["sarah@mergington.edu"]
+    },
+    "Art Studio": {
+        "description": "Explore painting, drawing, and various art mediums",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 18,
+        "participants": ["jessica@mergington.edu", "marcus@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Theater performances, acting, and stage production",
+        "schedule": "Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 24,
+        "participants": ["aiden@mergington.edu"]
+    },
+    "Debate Team": {
+        "description": "Develop public speaking and critical thinking skills through competitive debate",
+        "schedule": "Mondays and Fridays, 3:30 PM - 4:30 PM",
+        "max_participants": 14,
+        "participants": ["noah@mergington.edu", "ava@mergington.edu"]
+    },
+    "Science Club": {
+        "description": "Conduct experiments and explore scientific concepts through hands-on activities",
+        "schedule": "Tuesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 22,
+        "participants": ["grace@mergington.edu"]
     }
 }
 
@@ -61,6 +97,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up")
 
     # Add student
     activity["participants"].append(email)

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -20,12 +20,52 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const spotsLeft = details.max_participants - details.participants.length;
 
+        const participantsList = details.participants.length > 0
+          ? `<ul class="participants-list">${details.participants.map(p =>
+              `<li><span class="participant-email">${p}</span><button class="delete-btn" data-activity="${name}" data-email="${p}" title="Unregister">🗑️</button></li>`
+            ).join("")}</ul>`
+          : `<p class="no-participants">No participants yet. Be the first!</p>`;
+
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <strong>Participants:</strong>
+            ${participantsList}
+          </div>
         `;
+
+        // Attach unregister handlers
+        activityCard.querySelectorAll(".delete-btn").forEach(btn => {
+          btn.addEventListener("click", async () => {
+            const activity = btn.dataset.activity;
+            const email = btn.dataset.email;
+            try {
+              const response = await fetch(
+                `/activities/${encodeURIComponent(activity)}/signup?email=${encodeURIComponent(email)}`,
+                { method: "DELETE" }
+              );
+              const result = await response.json();
+              if (response.ok) {
+                messageDiv.textContent = result.message;
+                messageDiv.className = "success";
+                fetchActivities();
+              } else {
+                messageDiv.textContent = result.detail || "An error occurred";
+                messageDiv.className = "error";
+              }
+              messageDiv.classList.remove("hidden");
+              setTimeout(() => messageDiv.classList.add("hidden"), 5000);
+            } catch (error) {
+              messageDiv.textContent = "Failed to unregister. Please try again.";
+              messageDiv.className = "error";
+              messageDiv.classList.remove("hidden");
+              console.error("Error unregistering:", error);
+            }
+          });
+        });
 
         activitiesList.appendChild(activityCard);
 
@@ -62,6 +102,7 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,54 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid #e0e0e0;
+}
+
+.participants-list {
+  list-style: none;
+  padding-left: 0;
+  margin-top: 6px;
+}
+
+.participants-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.875rem;
+  color: #555;
+  padding: 3px 0;
+}
+
+.participant-email {
+  flex: 1;
+}
+
+.delete-btn {
+  background: none;
+  border: none;
+  padding: 2px 6px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  color: #c62828;
+  border-radius: 4px;
+  transition: background-color 0.15s;
+  line-height: 1;
+}
+
+.delete-btn:hover {
+  background-color: #ffebee;
+}
+
+.no-participants {
+  font-size: 0.875rem;
+  color: #999;
+  font-style: italic;
+  margin-top: 6px;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,131 @@
+import copy
+import pytest
+from fastapi.testclient import TestClient
+
+import src.app as app_module
+from src.app import app
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_activities():
+    """Restore the activities dict to its original state after each test."""
+    original = copy.deepcopy(app_module.activities)
+    yield
+    app_module.activities.clear()
+    app_module.activities.update(original)
+
+
+# ---------------------------------------------------------------------------
+# GET /activities
+# ---------------------------------------------------------------------------
+
+def test_get_activities_returns_200():
+    # Arrange — no setup needed
+
+    # Act
+    response = client.get("/activities")
+
+    # Assert
+    assert response.status_code == 200
+
+
+def test_get_activities_contains_expected_keys():
+    # Arrange
+    expected_activities = ["Chess Club", "Programming Class", "Gym Class"]
+
+    # Act
+    response = client.get("/activities")
+    data = response.json()
+
+    # Assert
+    for name in expected_activities:
+        assert name in data
+
+
+# ---------------------------------------------------------------------------
+# POST /activities/{activity_name}/signup
+# ---------------------------------------------------------------------------
+
+def test_signup_success():
+    # Arrange
+    activity_name = "Chess Club"
+    email = "newstudent@mergington.edu"
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup?email={email}")
+
+    # Assert
+    assert response.status_code == 200
+    assert email in app_module.activities[activity_name]["participants"]
+
+
+def test_signup_activity_not_found():
+    # Arrange
+    activity_name = "Nonexistent Club"
+    email = "student@mergington.edu"
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup?email={email}")
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_signup_already_registered():
+    # Arrange — register the student first
+    activity_name = "Chess Club"
+    email = "duplicate@mergington.edu"
+    client.post(f"/activities/{activity_name}/signup?email={email}")
+
+    # Act — attempt to register again
+    response = client.post(f"/activities/{activity_name}/signup?email={email}")
+
+    # Assert
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Student already signed up"
+
+
+# ---------------------------------------------------------------------------
+# DELETE /activities/{activity_name}/signup
+# ---------------------------------------------------------------------------
+
+def test_unregister_success():
+    # Arrange — ensure the student is registered
+    activity_name = "Chess Club"
+    email = "michael@mergington.edu"
+
+    # Act
+    response = client.delete(f"/activities/{activity_name}/signup?email={email}")
+
+    # Assert
+    assert response.status_code == 200
+    assert email not in app_module.activities[activity_name]["participants"]
+
+
+def test_unregister_activity_not_found():
+    # Arrange
+    activity_name = "Nonexistent Club"
+    email = "student@mergington.edu"
+
+    # Act
+    response = client.delete(f"/activities/{activity_name}/signup?email={email}")
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_unregister_student_not_signed_up():
+    # Arrange
+    activity_name = "Chess Club"
+    email = "notregistered@mergington.edu"
+
+    # Act
+    response = client.delete(f"/activities/{activity_name}/signup?email={email}")
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Student is not signed up for this activity"


### PR DESCRIPTION
This pull request introduces several new features and improvements to the student activities signup application. The main changes include adding new activities, implementing the ability for students to unregister from activities via both the backend API and frontend UI, enhancing the display of activity participants, and introducing automated tests for the signup and unregister functionality.

**Backend functionality:**

- Added support for unregistering from activities with a new `DELETE /activities/{activity_name}/signup` endpoint, including validation to ensure students can't unregister if they're not signed up.
- Expanded the `activities` data structure with several new activities such as "Basketball Team", "Tennis Club", "Art Studio", "Drama Club", "Debate Team", and "Science Club".

**Frontend enhancements:**

- Updated the UI to display a list of participants for each activity, including an "Unregister" (delete) button next to each participant. The frontend now supports unregistering students by calling the new backend endpoint and refreshing the activity list after changes. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R23-R69) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R105)
- Improved the visual styling for the participants section and unregister button, including styles for empty participant lists and button hover states.

**Testing:**

- Added a comprehensive test suite (`tests/test_app.py`) covering activity listing, signup, duplicate signup prevention, unregistering, and edge cases such as non-existent activities or students not registered.